### PR TITLE
Lazy load fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's a quick example to show a tooltip below a button:
 ```html
 <!-- positionV specifies where the tooltip should be displayed vertically, can be either top or bottom -->
 <!-- arrow tells the tooltip directive to show an arrow above the tooltip box -->
-<button ion-button [tooltip]="I'm a tooltip below a button" positionV="bottom" arrow>
+<button ion-button tooltip="I'm a tooltip below a button" positionV="bottom" arrow>
   Press me to see a tooltip
 </button>
 ```
@@ -34,7 +34,7 @@ And here's another example to show a tooltip below a nav button:
     <ion-title>Page title</ion-title>
     <ion-buttons end>
       <!-- navTooltip tells the tooltip directive that this is a nav button -->
-      <ion-button icon-only [tooltip]="Call" navTooltip>
+      <ion-button icon-only tooltip="Call" navTooltip>
         <ion-icon name="call"></ion-icon>
       </ion-button>
     </ion-buttons>
@@ -88,6 +88,9 @@ The `tooltip` directive takes a string, which will be used as the tooltip text. 
 
 #### `duration`
 (number) number of milliseconds to show the tooltip for. Defaults to `3000`.
+
+#### `active`
+(boolean) add this attribute or set it's value to true to display the tooltip. Defaults to `false`.
 
 <br><br>
 ## Contribution

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "4.1.3",
     "@angular/platform-browser-dynamic": "4.1.3",
     "@angular/platform-server": "4.1.3",
-    "ionic-angular": "3.5.0",
+    "ionic-angular": "3.6.1",
     "ionicons": "3.0.0",
     "rxjs": "5.4.1",
     "typescript": "2.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './tooltip-box.component';
 export * from './tooltip.directive';
 export * from './tooltips.module';
-export * from './tooltips.child.module';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './tooltip-box.component';
 export * from './tooltip.directive';
 export * from './tooltips.module';
+export * from './tooltips.child.module';

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -1,6 +1,6 @@
 import {
   Directive, ElementRef, Input, ApplicationRef, ComponentFactoryResolver,
-  ViewContainerRef, ComponentRef
+  ViewContainerRef, ComponentRef, AfterViewInit
 } from '@angular/core';
 import { Platform } from 'ionic-angular';
 import { TooltipBox } from './tooltip-box.component';
@@ -12,7 +12,7 @@ import { TooltipBox } from './tooltip-box.component';
     '(click)': 'event === "click" && trigger()'
   }
 })
-export class Tooltip {
+export class Tooltip implements AfterViewInit {
 
   @Input() tooltip: string;
 
@@ -38,18 +38,51 @@ export class Tooltip {
 
   @Input() duration: number = 3000;
 
+  @Input() set active(val: boolean) {
+    this._active = typeof val !== 'boolean' || val != false;
+    this._active
+      ? this.showTooltip()
+      : this._removeTooltip();
+  }
+  get active(): boolean { return this._active; }
+
   private _arrow: boolean = false;
   private _navTooltip: boolean = false;
   private tooltipElement: ComponentRef<TooltipBox>;
   private tooltipTimeout: any;
-  private canShow: boolean = true;
+  private _canShow: boolean = true;
+  private _active: boolean = false;
 
   constructor(
-      private el: ElementRef
-      , private appRef: ApplicationRef
-      , private platform: Platform
-      , private _componentFactoryResolver: ComponentFactoryResolver
+      private el: ElementRef, 
+      private appRef: ApplicationRef, 
+      private platform: Platform, 
+      private _componentFactoryResolver: ComponentFactoryResolver
   ) {}
+
+  /**
+   * Show the tooltip immediately after initiating view if set to 
+   */
+  ngAfterViewInit() {
+    if (this._active) {
+      this.trigger();
+    }
+  }
+
+  /**
+   * Set the canShow property 
+   * Ensure that tooltip is shown only if the tooltip string is not falsey
+   */
+  set canShow(show: boolean) {
+    this._canShow = show && Boolean(this.tooltip);
+  }
+
+  /**
+   * @return {boolean} TRUE if the tooltip can be shown
+   */
+  get canShow(): boolean {
+    return this._canShow;
+  }
 
   /**
    * Handles the click/press event and shows a tooltip.
@@ -99,7 +132,9 @@ export class Tooltip {
         tooltipComponent.arrow = arrowPosition;
       }
 
-      this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
+      if (!this._active) {
+        this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
+      }
 
     });
 
@@ -179,6 +214,7 @@ export class Tooltip {
   }
 
   private _resetTimer() {
+    this.active = false;
     clearTimeout(this.tooltipTimeout);
     this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
   }

--- a/src/tooltips.child.module.ts
+++ b/src/tooltips.child.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { IonicModule } from 'ionic-angular';
+import { Tooltip } from './tooltip.directive';
+import { TooltipBox } from './tooltip-box.component';
+
+export const childArgs: NgModule = {
+    entryComponents: [
+        TooltipBox
+    ],
+    declarations: [
+        Tooltip,
+        TooltipBox,
+    ],
+    imports: [
+    IonicModule
+    ],
+    exports: [
+    Tooltip
+    ]
+};
+
+@NgModule(childArgs)
+export class TooltipsChildModule {}

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,5 +1,5 @@
-import { TooltipsChildModule, childArgs } from './tooltips.child.module';
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { childArgs } from './tooltips.child.module';
+import { NgModule } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const rootArgs: NgModule = Object.assign({}, childArgs);

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,10 +1,10 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { IonicModule } from 'ionic-angular';
 import { Tooltip } from './tooltip.directive';
 import { TooltipBox } from './tooltip-box.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-@NgModule({
+const childArgs: NgModule = {
   entryComponents: [
     TooltipBox
   ],
@@ -13,11 +13,23 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         TooltipBox,
     ],
     imports: [
-      IonicModule,
-      BrowserAnimationsModule
+      IonicModule
     ],
     exports: [
       Tooltip
     ]
-})
-export class TooltipsModule {}
+};
+const rootArgs: NgModule = Object.assign({}, childArgs);
+rootArgs.imports.push(BrowserAnimationsModule);
+
+@NgModule(childArgs)
+export class TooltipsChildModule {}
+
+@NgModule(rootArgs)
+export class TooltipsModule {
+  static forChild(): ModuleWithProviders {
+    return {
+      ngModule: TooltipsChildModule
+    }
+  }
+}

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,35 +1,9 @@
+import { TooltipsChildModule, childArgs } from './tooltips.child.module';
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { IonicModule } from 'ionic-angular';
-import { Tooltip } from './tooltip.directive';
-import { TooltipBox } from './tooltip-box.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-const childArgs: NgModule = {
-  entryComponents: [
-    TooltipBox
-  ],
-    declarations: [
-        Tooltip,
-        TooltipBox,
-    ],
-    imports: [
-      IonicModule
-    ],
-    exports: [
-      Tooltip
-    ]
-};
 const rootArgs: NgModule = Object.assign({}, childArgs);
 rootArgs.imports.push(BrowserAnimationsModule);
 
-@NgModule(childArgs)
-export class TooltipsChildModule {}
-
 @NgModule(rootArgs)
-export class TooltipsModule {
-  static forChild(): ModuleWithProviders {
-    return {
-      ngModule: TooltipsChildModule
-    }
-  }
-}
+export class TooltipsModule {}


### PR DESCRIPTION
Allow Module loading in lazy loaded pages.

Usage:
```typescript
import { TooltipsChildModule } from 'ionic-tooltips/tooltips.child.module';
import { CommonModule } from '@angular/common';
import { HomePage } from './home';
import { NgModule } from '@angular/core';
import { IonicPageModule } from 'ionic-angular';

@NgModule({
  declarations: [
    HomePage,
  ],
  imports: [
    CommonModule,
    IonicPageModule.forChild(HomePage),
    TooltipsChildModule
  ],
  exports: [
    HomePage
  ]
})
export class HomePageModule {}
```