### PR TITLE
Lazy load fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './tooltip-box.component';
 export * from './tooltip.directive';
 export * from './tooltips.module';
-export * from './tooltips.child.module';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './tooltip-box.component';
 export * from './tooltip.directive';
 export * from './tooltips.module';
+export * from './tooltips.child.module';

--- a/src/tooltips.child.module.ts
+++ b/src/tooltips.child.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { IonicModule } from 'ionic-angular';
+import { Tooltip } from './tooltip.directive';
+import { TooltipBox } from './tooltip-box.component';
+
+export const childArgs: NgModule = {
+    entryComponents: [
+        TooltipBox
+    ],
+    declarations: [
+        Tooltip,
+        TooltipBox,
+    ],
+    imports: [
+    IonicModule
+    ],
+    exports: [
+    Tooltip
+    ]
+};
+
+@NgModule(childArgs)
+export class TooltipsChildModule {}

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,5 +1,5 @@
-import { TooltipsChildModule, childArgs } from './tooltips.child.module';
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { childArgs } from './tooltips.child.module';
+import { NgModule } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const rootArgs: NgModule = Object.assign({}, childArgs);

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,10 +1,10 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { IonicModule } from 'ionic-angular';
 import { Tooltip } from './tooltip.directive';
 import { TooltipBox } from './tooltip-box.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-@NgModule({
+const childArgs: NgModule = {
   entryComponents: [
     TooltipBox
   ],
@@ -13,11 +13,23 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         TooltipBox,
     ],
     imports: [
-      IonicModule,
-      BrowserAnimationsModule
+      IonicModule
     ],
     exports: [
       Tooltip
     ]
-})
-export class TooltipsModule {}
+};
+const rootArgs: NgModule = Object.assign({}, childArgs);
+rootArgs.imports.push(BrowserAnimationsModule);
+
+@NgModule(childArgs)
+export class TooltipsChildModule {}
+
+@NgModule(rootArgs)
+export class TooltipsModule {
+  static forChild(): ModuleWithProviders {
+    return {
+      ngModule: TooltipsChildModule
+    }
+  }
+}

--- a/src/tooltips.module.ts
+++ b/src/tooltips.module.ts
@@ -1,35 +1,9 @@
+import { TooltipsChildModule, childArgs } from './tooltips.child.module';
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { IonicModule } from 'ionic-angular';
-import { Tooltip } from './tooltip.directive';
-import { TooltipBox } from './tooltip-box.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-const childArgs: NgModule = {
-  entryComponents: [
-    TooltipBox
-  ],
-    declarations: [
-        Tooltip,
-        TooltipBox,
-    ],
-    imports: [
-      IonicModule
-    ],
-    exports: [
-      Tooltip
-    ]
-};
 const rootArgs: NgModule = Object.assign({}, childArgs);
 rootArgs.imports.push(BrowserAnimationsModule);
 
-@NgModule(childArgs)
-export class TooltipsChildModule {}
-
 @NgModule(rootArgs)
-export class TooltipsModule {
-  static forChild(): ModuleWithProviders {
-    return {
-      ngModule: TooltipsChildModule
-    }
-  }
-}
+export class TooltipsModule {}


### PR DESCRIPTION
Allow Module loading in lazy loaded pages.
closes #9 

Usage:

import { TooltipsChildModule } from 'ionic-tooltips/tooltips.child.module';
import { CommonModule } from '@angular/common';
import { HomePage } from './home';
import { NgModule } from '@angular/core';
import { IonicPageModule } from 'ionic-angular';

@NgModule({
  declarations: [
    HomePage,
  ],
  imports: [
    CommonModule,
    IonicPageModule.forChild(HomePage),
    TooltipsChildModule
  ],
  exports: [
    HomePage
  ]
})
export class HomePageModule {}