### PR TITLE
Show on hover on Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here's a quick example to show a tooltip below a button:
 ```html
 <!-- positionV specifies where the tooltip should be displayed vertically, can be either top or bottom -->
 <!-- arrow tells the tooltip directive to show an arrow above the tooltip box -->
-<button ion-button [tooltip]="I'm a tooltip below a button" positionV="bottom" arrow>
+<button ion-button tooltip="I'm a tooltip below a button" positionV="bottom" arrow>
   Press me to see a tooltip
 </button>
 ```
@@ -34,7 +34,7 @@ And here's another example to show a tooltip below a nav button:
     <ion-title>Page title</ion-title>
     <ion-buttons end>
       <!-- navTooltip tells the tooltip directive that this is a nav button -->
-      <ion-button icon-only [tooltip]="Call" navTooltip>
+      <ion-button icon-only tooltip="Call" navTooltip>
         <ion-icon name="call"></ion-icon>
       </ion-button>
     </ion-buttons>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This module is designed to work with `ionic-angular@^3.5.0` but it should work w
 
 ## Demo
 Below is a gif showing the module in action, you can also clone the example project here: https://github.com/zyra/ionic-tooltips-example
-<!-- TODO add gif here -->
+
+![Ionic Tooltips Demo](https://github.com/zyra/ionic-tooltips-example/blob/master/ionic-tooltips.gif?raw=true)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The `tooltip` directive takes a string, which will be used as the tooltip text. 
 #### `duration`
 (number) number of milliseconds to show the tooltip for. Defaults to `3000`.
 
+#### `active`
+(boolean) add this attribute or set it's value to true to display the tooltip. Defaults to `false`.
+
 <br><br>
 ## Contribution
 - **Having an issue**? or looking for support? [Open an issue](https://github.com/zyra/ionic-tooltips/issues/new) and we will get you the help you need.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The `tooltip` directive takes a string, which will be used as the tooltip text. 
 (string) specifies the horizontal position of the tooltip. Can be either `'right'` or `'left'`.
 
 #### `event`
-(string) the event to show the tooltip on. Can be either `'click'` or `'press'`. Defaults to `'press'`.
+(string) the event to show the tooltip on. Can be either `'hover'`, `'click'` or `'press'`. Defaults to `'press'`.  
+Note: `'hover'` only works on desktop.
 
 #### `arrow`
 (boolean) add this attribute or set it's value to true to show an arrow attached to the tooltip. Defaults to `false`.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "4.1.3",
     "@angular/platform-browser-dynamic": "4.1.3",
     "@angular/platform-server": "4.1.3",
-    "ionic-angular": "3.5.0",
+    "ionic-angular": "3.6.1",
     "ionicons": "3.0.0",
     "rxjs": "5.4.1",
     "typescript": "2.3.4",

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -39,19 +39,19 @@ export class Tooltip implements AfterViewInit {
   @Input() duration: number = 3000;
 
   @Input() set active(val: boolean) {
-    this._alwaysShow = typeof val !== 'boolean' || val != false;
-    this._alwaysShow
+    this._active = typeof val !== 'boolean' || val != false;
+    this._active
       ? this.showTooltip()
       : this._removeTooltip();
   }
-  get active(): boolean { return this._alwaysShow; }
+  get active(): boolean { return this._active; }
 
   private _arrow: boolean = false;
   private _navTooltip: boolean = false;
   private tooltipElement: ComponentRef<TooltipBox>;
   private tooltipTimeout: any;
   private _canShow: boolean = true;
-  private _alwaysShow: boolean = false;
+  private _active: boolean = false;
 
   constructor(
       private el: ElementRef, 
@@ -64,7 +64,7 @@ export class Tooltip implements AfterViewInit {
    * Show the tooltip immediately after initiating view if set to 
    */
   ngAfterViewInit() {
-    if (this._alwaysShow) {
+    if (this._active) {
       this.trigger();
     }
   }

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -43,7 +43,7 @@ export class Tooltip implements AfterViewInit {
   @Input() set active(val: boolean) {
     this._active = typeof val !== 'boolean' || val != false;
     this._active
-      ? this.showTooltip()
+      ? this.canShow && this.showTooltip()
       : this._removeTooltip();
   }
   get active(): boolean { return this._active; }
@@ -76,14 +76,14 @@ export class Tooltip implements AfterViewInit {
    * Ensure that tooltip is shown only if the tooltip string is not falsey
    */
   set canShow(show: boolean) {
-    this._canShow = show && Boolean(this.tooltip);
+    this._canShow = show;
   }
 
   /**
    * @return {boolean} TRUE if the tooltip can be shown
    */
   get canShow(): boolean {
-    return this._canShow;
+    return this._canShow && this.tooltip != "";
   }
 
   /**

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -10,7 +10,8 @@ import { TooltipBox } from './tooltip-box.component';
   host: {
     '(press)': 'event === "press" && trigger()',
     '(click)': 'event === "click" && trigger()',
-    '(hover)': 'event === "hover" && trigger()'
+    '(mouseenter)': 'event === "hover" && active = true',
+    '(mouseleave)': 'event === "hover" && active = false'
   }
 })
 export class Tooltip implements AfterViewInit {

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -1,6 +1,6 @@
 import {
   Directive, ElementRef, Input, ApplicationRef, ComponentFactoryResolver,
-  ViewContainerRef, ComponentRef
+  ViewContainerRef, ComponentRef, AfterViewInit
 } from '@angular/core';
 import { Platform } from 'ionic-angular';
 import { TooltipBox } from './tooltip-box.component';
@@ -12,7 +12,7 @@ import { TooltipBox } from './tooltip-box.component';
     '(click)': 'event === "click" && trigger()'
   }
 })
-export class Tooltip {
+export class Tooltip implements AfterViewInit {
 
   @Input() tooltip: string;
 
@@ -38,18 +38,51 @@ export class Tooltip {
 
   @Input() duration: number = 3000;
 
+  @Input() set alwaysShow(val: boolean) {
+    this._alwaysShow = typeof val !== 'boolean' || val != false;
+    this._alwaysShow
+      ? this.showTooltip()
+      : this._removeTooltip();
+  }
+  get alwaysShow(): boolean { return this._alwaysShow; }
+
   private _arrow: boolean = false;
   private _navTooltip: boolean = false;
   private tooltipElement: ComponentRef<TooltipBox>;
   private tooltipTimeout: any;
-  private canShow: boolean = true;
+  private _canShow: boolean = true;
+  private _alwaysShow: boolean = false;
 
   constructor(
-      private el: ElementRef
-      , private appRef: ApplicationRef
-      , private platform: Platform
-      , private _componentFactoryResolver: ComponentFactoryResolver
+      private el: ElementRef, 
+      private appRef: ApplicationRef, 
+      private platform: Platform, 
+      private _componentFactoryResolver: ComponentFactoryResolver
   ) {}
+
+  /**
+   * Show the tooltip immediately after initiating view if set to 
+   */
+  ngAfterViewInit() {
+    if (this._alwaysShow) {
+      this.trigger();
+    }
+  }
+
+  /**
+   * Set the canShow property 
+   * Ensure that tooltip is shown only if the tooltip string is not falsey
+   */
+  set canShow(show: boolean) {
+    this._canShow = show && Boolean(this.tooltip);
+  }
+
+  /**
+   * @return {boolean} TRUE if the tooltip can be shown
+   */
+  get canShow(): boolean {
+    return this._canShow;
+  }
 
   /**
    * Handles the click/press event and shows a tooltip.

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -132,7 +132,9 @@ export class Tooltip implements AfterViewInit {
         tooltipComponent.arrow = arrowPosition;
       }
 
-      this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
+      if (!this._active) {
+        this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
+      }
 
     });
 
@@ -212,6 +214,7 @@ export class Tooltip implements AfterViewInit {
   }
 
   private _resetTimer() {
+    this.active = false;
     clearTimeout(this.tooltipTimeout);
     this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
   }

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -38,13 +38,13 @@ export class Tooltip implements AfterViewInit {
 
   @Input() duration: number = 3000;
 
-  @Input() set alwaysShow(val: boolean) {
+  @Input() set active(val: boolean) {
     this._alwaysShow = typeof val !== 'boolean' || val != false;
     this._alwaysShow
       ? this.showTooltip()
       : this._removeTooltip();
   }
-  get alwaysShow(): boolean { return this._alwaysShow; }
+  get active(): boolean { return this._alwaysShow; }
 
   private _arrow: boolean = false;
   private _navTooltip: boolean = false;


### PR DESCRIPTION
Listen to `mouseenter` and `mouseleave` events to reproduce hover tooltips on desktop

closes #3 