### PR TITLE
Add "center" option for tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `tooltip` directive takes a string, which will be used as the tooltip text. 
 (string) specifies the vertical position of the tooltip. Can be either `'top'` or `'bottom'`.
 
 #### `positionH`
-(string) specifies the horizontal position of the tooltip. Can be either `'right'` or `'left'`.
+(string) specifies the horizontal position of the tooltip. Can be either `'right'` or `'left'` or `'center'`.
 
 #### `event`
 (string) the event to show the tooltip on. Can be either `'hover'`, `'click'` or `'press'`. Defaults to `'press'`.  

--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -183,6 +183,8 @@ export class Tooltip implements AfterViewInit {
       positionLeft = rect.right + spacing;
     } else if (this.positionH === 'left') {
       positionLeft = rect.left - spacing - tooltipNativeElement.offsetWidth;
+    } else if (this.positionH === 'center') {
+    	positionLeft = rect.left - (spacing + tooltipNativeElement.offsetWidth) / 2
     } else if (this.navTooltip) {
       positionLeft = rect.left + el.offsetWidth / 2;
     } else {


### PR DESCRIPTION
I needed a tooltip that appeared centered under my element. I figure others might as well so here's a PR for it.